### PR TITLE
Support for k8s 1.29 and below

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: ncm-issuer
 appVersion: 1.1.0
 version: 1.1.0
-kubeVersion: ">= 1.18.0-0 < 1.28.0-0"
+kubeVersion: ">= 1.18.0-0 < 1.30.0-0"
 description: A Helm chart for cert-manager external issuer with NCM (NetGuard Certificate Manager)
 home: https://github.com/nokia/ncm-issuer
 sources:


### PR DESCRIPTION
Currently, this issuer supports upto Kubernetes v1.27. However, latest cert-manager release 1.14 provides support for upto Kubernetes v1.29 (https://cert-manager.io/docs/releases/#currently-supported-releases). This change helps support the issuer on latest cert-manager 1.14 across it's all supported kube versions.