### PR TITLE
ci: unblock CI and bump golangci-lint-action to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: ${{ fromJSON(needs.go-versions.outputs.go-mod-version) }}
 
       - name: "golangci-lint"
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v5
         with:
           version: v1.54
           only-new-issues: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,7 +39,7 @@ jobs:
         run: go get .
 
       - name: "golangci-lint"
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v5
         with:
           version: v1.54
           only-new-issues: true

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9
 
 pack-app: docker-save
 	rm -rf builds/$(APP_NAME) && mkdir -p builds/$(APP_NAME)/


### PR DESCRIPTION
## Description
This PR fixes errors due to conflicting caching by setup-go and golangci-lint-action as well as introduces workaround for kubernetes-sigs/controller-runtime#2720.