### PR TITLE
Fix, replacing the kubectl plugin with recommended cert-manager binary

### DIFF
--- a/.github/workflows/caname-id-test.yml
+++ b/.github/workflows/caname-id-test.yml
@@ -25,6 +25,9 @@ jobs:
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
 
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
+
     - name: "build ncm-issuer image"
       run: |
         make docker-build
@@ -172,6 +175,9 @@ jobs:
         sudo microk8s enable dns
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
+
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
 
     - name: "build ncm-issuer image"
       run: |

--- a/.github/workflows/clientauth-test.yml
+++ b/.github/workflows/clientauth-test.yml
@@ -56,7 +56,7 @@ jobs:
         sudo microk8s.kubectl get pods -A
         sudo microk8s.kubectl -n cert-manager logs `sudo microk8s.kubectl get pods -n cert-manager -l app=cert-manager -o jsonpath='{.items[0].metadata.name}'`|tail -25
    
-    - name: "install kubectl cert-manager plugin"
+    - name: "install cmctl"
       run: |
           OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
           sudo chmod +x cmctl

--- a/.github/workflows/clientauth-test.yml
+++ b/.github/workflows/clientauth-test.yml
@@ -58,9 +58,9 @@ jobs:
    
     - name: "install kubectl cert-manager plugin"
       run: |
-          OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o kubectl-cert-manager.tar.gz "https://github.com/cert-manager/cert-manager/releases/download/v${{ matrix.certmgr-version }}/kubectl-cert_manager-$OS-$ARCH.tar.gz"
-          tar xzf kubectl-cert-manager.tar.gz
-          sudo mv kubectl-cert_manager /usr/local/bin
+          OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
+          chmod +x cmctl
+          sudo mv cmctl /usr/local/bin
 
     - name: "install yq"
       run: sudo snap install yq
@@ -133,7 +133,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -145,7 +145,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo microk8s.kubectl cert-manager renew ncm-cert -n ncm-issuer
+        sudo cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 15s"
       uses: juliangruber/sleep-action@v1
@@ -155,9 +155,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 

--- a/.github/workflows/clientauth-test.yml
+++ b/.github/workflows/clientauth-test.yml
@@ -59,7 +59,7 @@ jobs:
     - name: "install kubectl cert-manager plugin"
       run: |
           OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
-          chmod +x cmctl
+          sudo chmod +x cmctl
           sudo mv cmctl /usr/local/bin
 
     - name: "install yq"

--- a/.github/workflows/clientauth-test.yml
+++ b/.github/workflows/clientauth-test.yml
@@ -30,6 +30,9 @@ jobs:
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
 
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
+
     - name: "build ncm-issuer image"
       run: |
         make docker-build
@@ -133,7 +136,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -145,7 +148,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo cmctl renew ncm-cert -n ncm-issuer
+        sudo -E cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 15s"
       uses: juliangruber/sleep-action@v1
@@ -155,9 +158,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo cmctl status certificate status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 

--- a/.github/workflows/clientauth-test.yml
+++ b/.github/workflows/clientauth-test.yml
@@ -158,7 +158,7 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo -E cmctl status certificate status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo -E cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der

--- a/.github/workflows/pkey-tests.yml
+++ b/.github/workflows/pkey-tests.yml
@@ -28,6 +28,9 @@ jobs:
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
 
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
+
     - name: "build ncm-issuer image"
       run: |
         make docker-build
@@ -127,7 +130,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -143,7 +146,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo cmctl renew ncm-cert -n ncm-issuer
+        sudo -E cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 15s"
       uses: juliangruber/sleep-action@v1
@@ -153,9 +156,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 
@@ -205,6 +208,9 @@ jobs:
         sudo microk8s enable dns
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
+
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
 
     - name: "build ncm-issuer image"
       run: |
@@ -304,7 +310,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -320,7 +326,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo cmctl renew ncm-cert -n ncm-issuer
+        sudo -E cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 15s"
       uses: juliangruber/sleep-action@v1
@@ -330,9 +336,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 

--- a/.github/workflows/pkey-tests.yml
+++ b/.github/workflows/pkey-tests.yml
@@ -55,11 +55,11 @@ jobs:
         sudo microk8s.kubectl -n cert-manager logs `sudo microk8s.kubectl get pods -n cert-manager -l app=cert-manager -o jsonpath='{.items[0].metadata.name}'`|tail -25
    
 
-    - name: "install kubectl cert-manager plugin"
+    - name: "install cmctl"
       run: |
-          OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o kubectl-cert-manager.tar.gz "https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERTMGR_VERSION }}/kubectl-cert_manager-$OS-$ARCH.tar.gz"
-          tar xzf kubectl-cert-manager.tar.gz
-          sudo mv kubectl-cert_manager /usr/local/bin
+          OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
+          sudo chmod +x cmctl
+          sudo mv cmctl /usr/local/bin
 
     - name: "install yq"
       run: sudo snap install yq
@@ -127,7 +127,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -143,7 +143,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo microk8s.kubectl cert-manager renew ncm-cert -n ncm-issuer
+        sudo cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 15s"
       uses: juliangruber/sleep-action@v1
@@ -153,9 +153,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 
@@ -232,11 +232,11 @@ jobs:
         sudo microk8s.kubectl get pods -A
         sudo microk8s.kubectl -n cert-manager logs `sudo microk8s.kubectl get pods -n cert-manager -l app=cert-manager -o jsonpath='{.items[0].metadata.name}'`|tail -25
 
-    - name: "install kubectl cert-manager plugin"
+    - name: "install cmctl"
       run: |
-          OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o kubectl-cert-manager.tar.gz "https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERTMGR_VERSION }}/kubectl-cert_manager-$OS-$ARCH.tar.gz"
-          tar xzf kubectl-cert-manager.tar.gz
-          sudo mv kubectl-cert_manager /usr/local/bin
+          OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
+          sudo chmod +x cmctl
+          sudo mv cmctl /usr/local/bin
 
     - name: "install yq"
       run: sudo snap install yq
@@ -304,7 +304,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -320,7 +320,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo microk8s.kubectl cert-manager renew ncm-cert -n ncm-issuer
+        sudo cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 15s"
       uses: juliangruber/sleep-action@v1
@@ -330,9 +330,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 

--- a/.github/workflows/san-test.yml
+++ b/.github/workflows/san-test.yml
@@ -41,6 +41,9 @@ jobs:
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
 
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
+
     - name: "build ncm-issuer image"
       run: |
         make docker-build

--- a/.github/workflows/signer-tests.yml
+++ b/.github/workflows/signer-tests.yml
@@ -56,11 +56,11 @@ jobs:
         sudo microk8s.kubectl get pods -A
         sudo microk8s.kubectl -n cert-manager logs `sudo microk8s.kubectl get pods -n cert-manager -l app=cert-manager -o jsonpath='{.items[0].metadata.name}'`|tail -25
         
-    - name: "install kubectl cert-manager plugin"
+    - name: "install cmctl"
       run: |
-          OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o kubectl-cert-manager.tar.gz "https://github.com/cert-manager/cert-manager/releases/download/v${{ matrix.certmgr-version }}/kubectl-cert_manager-$OS-$ARCH.tar.gz"
-          tar xzf kubectl-cert-manager.tar.gz
-          sudo mv kubectl-cert_manager /usr/local/bin
+          OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
+          sudo chmod +x cmctl
+          sudo mv cmctl /usr/local/bin
 
     - name: "install yq"
       run: sudo snap install yq
@@ -124,7 +124,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -138,7 +138,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo microk8s.kubectl cert-manager renew ncm-cert -n ncm-issuer
+        sudo cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 10s"
       uses: juliangruber/sleep-action@v1
@@ -148,9 +148,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer
+        sudo cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 
@@ -229,11 +229,11 @@ jobs:
         sudo microk8s.kubectl get pods -A
         sudo microk8s.kubectl -n cert-manager logs `sudo microk8s.kubectl get pods -n cert-manager -l app=cert-manager -o jsonpath='{.items[0].metadata.name}'`|tail -25
    
-    - name: "install kubectl cert-manager plugin"
+    - name: "install cmctl"
       run: |
-          OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sSL -o kubectl-cert-manager.tar.gz "https://github.com/cert-manager/cert-manager/releases/download/v${{ matrix.certmgr-version }}/kubectl-cert_manager-$OS-$ARCH.tar.gz"
-          tar xzf kubectl-cert-manager.tar.gz
-          sudo mv kubectl-cert_manager /usr/local/bin
+          OS=$(uname -s | tr A-Z a-z); ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); curl -fsSL -o cmctl https://github.com/cert-manager/cmctl/releases/latest/download/cmctl_${OS}_${ARCH}
+          sudo chmod +x cmctl
+          sudo mv cmctl /usr/local/bin
 
     - name: "install yq"
       run: sudo snap install yq
@@ -308,7 +308,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-cert
+        sudo cmctl status certificate ncm-cert -n ncm-cert
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-cert
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-cert  | grep "The certificate has been successfully issued"
@@ -322,7 +322,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo microk8s.kubectl cert-manager renew ncm-cert -n ncm-cert
+        sudo cmctl renew ncm-cert -n ncm-cert
 
     - name: "sleep for 10s"
       uses: juliangruber/sleep-action@v1
@@ -332,9 +332,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-cert
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-cert
+        sudo cmctl status certificate ncm-cert -n ncm-cert
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo microk8s.kubectl cert-manager status certificate ncm-cert -n ncm-cert | grep "No CertificateRequest found for this Certificate"
+        sudo cmctl status certificate ncm-cert -n ncm-cert | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-cert | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 

--- a/.github/workflows/signer-tests.yml
+++ b/.github/workflows/signer-tests.yml
@@ -30,6 +30,9 @@ jobs:
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
 
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
+
     - name: "install cert-manager charts"
       run: |
         sudo microk8s.kubectl create namespace cert-manager
@@ -124,7 +127,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-issuer  | grep "The certificate has been successfully issued"
@@ -138,7 +141,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo cmctl renew ncm-cert -n ncm-issuer
+        sudo -E cmctl renew ncm-cert -n ncm-issuer
 
     - name: "sleep for 10s"
       uses: juliangruber/sleep-action@v1
@@ -148,9 +151,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-issuer
-        sudo cmctl status certificate ncm-cert -n ncm-issuer
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
+        sudo -E cmctl status certificate ncm-cert -n ncm-issuer | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-issuer | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 
@@ -202,6 +205,9 @@ jobs:
         sudo microk8s enable dns
         echo K8S_VERSION=$(sudo microk8s.kubectl version --short=true|grep -Po 'Server Version: \K.*' -m 1) >> $GITHUB_ENV
     - run: echo "k8s ${{ env.K8S_VERSION }}"
+
+    - name: Set KUBECONFIG for MicroK8s
+      run: echo "KUBECONFIG=/var/snap/microk8s/current/credentials/client.config" >> $GITHUB_ENV
 
     - name: "build ncm-issuer image"
       run: |
@@ -308,7 +314,7 @@ jobs:
 
     - name: "check certificate resource"
       run: |
-        sudo cmctl status certificate ncm-cert -n ncm-cert
+        sudo -E cmctl status certificate ncm-cert -n ncm-cert
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-cert
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
         sudo microk8s.kubectl describe cert ncm-cert -n ncm-cert  | grep "The certificate has been successfully issued"
@@ -322,7 +328,7 @@ jobs:
 
     - name: "renew certificate"
       run: |
-        sudo cmctl renew ncm-cert -n ncm-cert
+        sudo -E cmctl renew ncm-cert -n ncm-cert
 
     - name: "sleep for 10s"
       uses: juliangruber/sleep-action@v1
@@ -332,9 +338,9 @@ jobs:
     - name: "check certificate resource"
       run: |
         sudo microk8s.kubectl get certificaterequest -n ncm-cert
-        sudo cmctl status certificate ncm-cert -n ncm-cert
+        sudo -E cmctl status certificate ncm-cert -n ncm-cert
         sudo microk8s.kubectl -n ncm-issuer logs `sudo microk8s.kubectl get pods -A -l app=ncm-issuer -o jsonpath='{.items[0].metadata.name}'`|tail -25
-        sudo cmctl status certificate ncm-cert -n ncm-cert | grep "No CertificateRequest found for this Certificate"
+        sudo -E cmctl status certificate ncm-cert -n ncm-cert | grep "No CertificateRequest found for this Certificate"
         sudo microk8s.kubectl describe certificaterequest ncm-cert -n ncm-cert | grep "Certificate:" | awk '{print $2}' | base64 -d > /tmp/cert.der
         openssl x509 -in /tmp/cert.der -text -noout
 


### PR DESCRIPTION
Cert-manager has stopped releasing the kubectl plugin in favor of the standalone binary.
Project CI jobs were failing. 

Recommended binary was added and used instead, unfortunately the cmctl is not a kubectl plugin so we need to configure KUBECONFIG for it and mane sure that command with sudo will access env variable.

Another approach would be coping microk8s config to default path in /root/.kube it was not chosen. 