### PR TITLE
Added parameters notBefore and notAfter to the certificate requests

### DIFF
--- a/pkg/ncmapi/client.go
+++ b/pkg/ncmapi/client.go
@@ -25,7 +25,7 @@ import (
 type ExternalClient interface {
 	GetCAs() (*CAsResponse, error)
 	GetCA(path string) (*CAResponse, error)
-	SendCSR(pem []byte, CA *CAResponse, profileID string) (*CSRResponse, error)
+	SendCSR(pem []byte, CA *CAResponse,duration *metav1.Duration, profileID string) (*CSRResponse, error)
 	CheckCSRStatus(path string) (*CSRStatusResponse, error)
 	DownloadCertificate(path string) (*CertificateDownloadResponse, error)
 	DownloadCertificateInPEM(path string) ([]byte, error)

--- a/pkg/provisioner/ncm.go
+++ b/pkg/provisioner/ncm.go
@@ -143,7 +143,7 @@ func (p *Provisioner) Sign(cr *cmapi.CertificateRequest) ([]byte, []byte, string
 		return p.handleAlreadySentCSR(cr.Namespace, cr.Annotations[cmapi.CertificateNameKey], certChain, wantedCA)
 	}
 
-	csrResp, err := p.NCMClient.SendCSR(cr.Spec.Request, signingCA, p.NCMConfig.ProfileID)
+	csrResp, err := p.NCMClient.SendCSR(cr.Spec.Request, signingCA, cr.Spec.Duration, p.NCMConfig.ProfileID)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("failed to send CSR, err: %w", err)
 	}

--- a/test/unit/gen/ncmapi.go
+++ b/test/unit/gen/ncmapi.go
@@ -202,7 +202,7 @@ func (fc *FakeClient) GetCA(path string) (*ncmapi.CAResponse, error) {
 	return fc.GetCAFn(path)
 }
 
-func (fc *FakeClient) SendCSR([]byte, *ncmapi.CAResponse, string) (*ncmapi.CSRResponse, error) {
+func (fc *FakeClient) SendCSR([]byte, *ncmapi.CAResponse, *metav1.Duration, string) (*ncmapi.CSRResponse, error) {
 	return fc.SendCSRFn()
 }
 


### PR DESCRIPTION
Added parameters notBefore and notAfter to the certificate requests send to the NCM. They are calculated based on the Duration parameter defined in cert-manager.io/v1 Certificate object kind (notBefore is set to the current time when cert is being enrolled).